### PR TITLE
Translate reflection tutorial notebook to Korean

### DIFF
--- a/docs/docs/tutorials/reflection/reflection.ipynb
+++ b/docs/docs/tutorials/reflection/reflection.ipynb
@@ -10,15 +10,15 @@
    "id": "492f050f-3dc3-44fa-8fdc-03362afd5488",
    "metadata": {},
    "source": [
-    "# Reflection\n",
+    "# 성찰(Reflection)\n",
     "\n",
     "\n",
-    "In the context of LLM agent building, reflection refers to the process of prompting an LLM to observe its past steps (along with potential observations from tools/the environment) to assess the quality of the chosen actions.\n",
-    "This is then used downstream for things like re-planning, search, or evaluation.\n",
+    "LLM 에이전트를 구축하는 맥락에서 성찰이란 LLM이 과거 단계(도구나 환경으로부터 얻은 관측과 함께)를 되돌아보며 자신이 선택한 행동의 품질을 평가하도록 프롬프트하는 과정을 의미합니다.\n",
+    "이 과정은 이후 재계획, 탐색, 평가 등의 작업에 활용됩니다.\n",
     "\n",
     "![Reflection](attachment:fc393f72-3401-4b86-b0d3-e4789b640a27.png)\n",
     "\n",
-    "This notebook demonstrates a very simple form of reflection in LangGraph."
+    "이 노트북은 LangGraph에서 아주 단순한 형태의 성찰 기법을 시연합니다."
    ]
   },
   {
@@ -26,9 +26,9 @@
    "id": "3ef94e7e-c9a5-4eee-a865-acf411b5c235",
    "metadata": {},
    "source": [
-    "## Setup\n",
+    "## 준비\n",
     "\n",
-    "First, let's install our required packages and set our API keys"
+    "먼저 필요한 패키지를 설치하고 API 키를 설정해 보겠습니다"
    ]
   },
   {
@@ -69,9 +69,9 @@
    "metadata": {},
    "source": [
     "<div class=\"admonition tip\">\n",
-    "    <p class=\"admonition-title\">Set up <a href=\"https://smith.langchain.com\">LangSmith</a> for LangGraph development</p>\n",
+    "    <p class=\"admonition-title\">LangGraph 개발을 위해 <a href=\"https://smith.langchain.com\">LangSmith</a> 설정하기</p>\n",
     "    <p style=\"padding-top: 5px;\">\n",
-    "        Sign up for LangSmith to quickly spot issues and improve the performance of your LangGraph projects. LangSmith lets you use trace data to debug, test, and monitor your LLM apps built with LangGraph — read more about how to get started <a href=\"https://docs.smith.langchain.com\">here</a>. \n",
+    "        LangSmith에 가입하면 LangGraph 프로젝트의 문제를 빠르게 찾아내고 성능을 향상시킬 수 있습니다. LangSmith는 LangGraph로 구축한 LLM 앱의 실행 추적 데이터를 활용해 디버깅하고, 테스트하며, 모니터링할 수 있게 해 줍니다. 시작하는 방법은 <a href=\"https://docs.smith.langchain.com\">여기</a>에서 자세히 확인하세요. \n",
     "    </p>\n",
     "</div>"
    ]
@@ -81,9 +81,9 @@
    "id": "f27bcc4a-aaa5-46bd-8163-3e0e90cb66e6",
    "metadata": {},
    "source": [
-    "## Generate\n",
+    "## 생성\n",
     "\n",
-    "For our example, we will create a \"5 paragraph essay\" generator. First, create the generator:\n"
+    "이 예제에서는 \"5단락 에세이\" 생성기를 만들어 보겠습니다. 먼저 생성기를 정의합니다:\n"
    ]
   },
   {
@@ -161,7 +161,7 @@
    "id": "b0b276e7-c392-4eec-be75-c77bd130379d",
    "metadata": {},
    "source": [
-    "### Reflect"
+    "### 성찰"
    ]
   },
   {
@@ -238,9 +238,9 @@
    "id": "6daf926c-1174-4e96-91b9-57c57cfce40d",
    "metadata": {},
    "source": [
-    "### Repeat\n",
+    "### 반복\n",
     "\n",
-    "And... that's all there is too it! You can repeat in a loop for a fixed number of steps, or use an LLM (or other check) to decide when the finished product is good enough."
+    "이게 전부입니다! 고정된 횟수만큼 루프를 돌며 반복할 수도 있고, LLM(또는 다른 검사)을 사용해 산출물이 충분히 만족스러운지 판단할 수도 있습니다."
    ]
   },
   {
@@ -307,9 +307,9 @@
    "id": "b63a9d93-a14d-4e41-a4bb-a4cd31713f44",
    "metadata": {},
    "source": [
-    "## Define graph\n",
+    "## 그래프 정의\n",
     "\n",
-    "Now that we've shown each step in isolation, we can wire it up in a graph."
+    "각 단계를 개별적으로 살펴보았으니 이제 그래프로 연결해 보겠습니다."
    ]
   },
   {
@@ -605,9 +605,9 @@
     "jp-MarkdownHeadingCollapsed": true
    },
    "source": [
-    "## Conclusion\n",
+    "## 마무리\n",
     "\n",
-    "Now that you've applied reflection to an LLM agent, I'll note one thing: self-reflection is inherently cyclic: it is much more effective if the reflection step has additional context or feedback (from tool observations, checks, etc.). If, like in the scenario above, the reflection step simply prompts the LLM to reflect on its output, it can still benefit the output quality (since the LLM then has multiple \"shots\" at getting a good output), but it's less guaranteed.\n"
+    "이제 LLM 에이전트에 성찰 단계를 적용해 보았으니 한 가지를 짚고 넘어가겠습니다. 자기 성찰은 본질적으로 순환적이기 때문에, 도구 관측이나 점검과 같은 추가 맥락이나 피드백이 함께할 때 훨씬 더 효과적입니다. 위 시나리오처럼 성찰 단계가 단지 LLM에게 자신의 출력을 되돌아보라고 요청하는 것이라도 여러 번의 \"기회\"를 제공한다는 점에서 출력 품질을 높이는 데 도움이 되지만, 항상 보장되는 것은 아닙니다.\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- translate the reflection tutorial notebook markdown content into Korean, including section headings and descriptions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd0bb206f88322ae20217058957510