### PR TITLE
Translate plan-and-execute notebook to Korean

### DIFF
--- a/docs/docs/tutorials/plan-and-execute/plan-and-execute.ipynb
+++ b/docs/docs/tutorials/plan-and-execute/plan-and-execute.ipynb
@@ -10,27 +10,24 @@
    "id": "79b5811c-1074-495f-9722-8325b5e717d3",
    "metadata": {},
    "source": [
-    "# Plan-and-Execute\n",
+    "# 계획-실행\n",
     "\n",
-    "This notebook shows how to create a \"plan-and-execute\" style agent. This is heavily inspired by the [Plan-and-Solve](https://arxiv.org/abs/2305.04091) paper as well as the [Baby-AGI](https://github.com/yoheinakajima/babyagi) project.\n",
+    "이 노트북은 \"계획-실행(plan-and-execute)\" 스타일의 에이전트를 만드는 방법을 보여줍니다. 이는 [Plan-and-Solve](https://arxiv.org/abs/2305.04091) 논문과 [Baby-AGI](https://github.com/yoheinakajima/babyagi) 프로젝트에서 큰 영감을 받았습니다.\n",
     "\n",
-    "The core idea is to first come up with a multi-step plan, and then go through that plan one item at a time.\n",
-    "After accomplishing a particular task, you can then revisit the plan and modify as appropriate.\n",
+    "핵심 아이디어는 먼저 여러 단계의 계획을 세운 다음 그 계획을 한 항목씩 수행하는 것입니다.\n",
+    "특정 작업을 완료한 뒤에는 계획을 다시 살펴보고 필요에 따라 수정할 수 있습니다.\n",
     "\n",
-    "\n",
-    "The general computational graph looks like the following:\n",
+    "일반적인 계산 그래프는 다음과 같습니다.\n",
     "\n",
     "![plan-and-execute diagram](attachment:86cf6404-3d9b-41cb-ab97-5e451f576620.png)\n",
     "\n",
+    "이는 한 번에 한 단계씩 생각하는 일반적인 [ReAct](https://arxiv.org/abs/2210.03629) 스타일의 에이전트와 비교됩니다.\n",
+    "\"계획-실행\" 스타일 에이전트의 장점은 다음과 같습니다.\n",
     "\n",
-    "This compares to a typical [ReAct](https://arxiv.org/abs/2210.03629) style agent where you think one step at a time.\n",
-    "The advantages of this \"plan-and-execute\" style agent are:\n",
+    "1. 명시적인 장기 계획 수립(이는 매우 강력한 LLM에게도 어려울 수 있습니다)\n",
+    "2. 실행 단계에서는 더 작거나 약한 모델을 사용하고, 계획 단계에서만 더 크고 성능이 좋은 모델을 사용할 수 있는 능력\n",
     "\n",
-    "1. Explicit long term planning (which even really strong LLMs can struggle with)\n",
-    "2. Ability to use smaller/weaker models for the execution step, only using larger/better models for the planning step\n",
-    "\n",
-    "\n",
-    "The following walkthrough demonstrates how to do so in LangGraph. The resulting agent will leave a trace like the following example: ([link](https://smith.langchain.com/public/d46e24d3-dda6-44d5-9550-b618fca4e0d4/r))."
+    "아래의 단계별 안내는 LangGraph에서 이를 구현하는 방법을 보여줍니다. 완성된 에이전트는 다음 예시와 같은 추적 결과를 남깁니다: ([link](https://smith.langchain.com/public/d46e24d3-dda6-44d5-9550-b618fca4e0d4/r))."
    ]
   },
   {
@@ -38,9 +35,9 @@
    "id": "a44a72d6-7e0c-4478-9d20-4c09000420a8",
    "metadata": {},
    "source": [
-    "## Setup\n",
+    "## 준비\n",
     "\n",
-    "First, we need to install the packages required."
+    "먼저 필요한 패키지를 설치합니다."
    ]
   },
   {
@@ -59,7 +56,7 @@
    "id": "35f267b0-98db-4a59-8b2c-a23f795576ff",
    "metadata": {},
    "source": [
-    "Next, we need to set API keys for OpenAI (the LLM we will use) and Tavily (the search tool we will use)"
+    "다음으로 OpenAI(사용할 LLM)와 Tavily(사용할 검색 도구)의 API 키를 설정해야 합니다."
    ]
   },
   {
@@ -88,9 +85,9 @@
    "metadata": {},
    "source": [
     "<div class=\"admonition tip\">\n",
-    "    <p class=\"admonition-title\">Set up <a href=\"https://smith.langchain.com\">LangSmith</a> for LangGraph development</p>\n",
+    "    <p class=\"admonition-title\"><a href=\"https://smith.langchain.com\">LangSmith</a>로 LangGraph 개발 환경 준비하기</p>\n",
     "    <p style=\"padding-top: 5px;\">\n",
-    "        Sign up for LangSmith to quickly spot issues and improve the performance of your LangGraph projects. LangSmith lets you use trace data to debug, test, and monitor your LLM apps built with LangGraph — read more about how to get started <a href=\"https://docs.smith.langchain.com\">here</a>. \n",
+    "        LangSmith에 가입하면 LangGraph 프로젝트의 문제를 빠르게 찾아내고 성능을 향상시킬 수 있습니다. LangSmith는 LangGraph로 구축한 LLM 앱의 추적 데이터를 활용해 디버깅하고, 테스트하고, 모니터링할 수 있도록 도와줍니다. 시작하는 방법은 <a href=\"https://docs.smith.langchain.com\">여기</a>에서 자세히 확인하세요. \n",
     "    </p>\n",
     "</div>"
    ]
@@ -100,9 +97,9 @@
    "id": "6c5fb09a-0311-44c2-b243-d0e80de78902",
    "metadata": {},
    "source": [
-    "## Define Tools\n",
+    "## 도구 정의\n",
     "\n",
-    "We will first define the tools we want to use. For this simple example, we will use a built-in search tool via Tavily. However, it is really easy to create your own tools - see documentation [here](https://python.langchain.com/docs/how_to/custom_tools) on how to do that."
+    "먼저 사용할 도구를 정의하겠습니다. 이 간단한 예제에서는 Tavily를 통해 제공되는 기본 제공 검색 도구를 사용합니다. 하지만 직접 도구를 만드는 것도 매우 쉽습니다. 방법은 [문서](https://python.langchain.com/docs/how_to/custom_tools)에서 확인할 수 있습니다."
    ]
   },
   {
@@ -122,10 +119,10 @@
    "id": "3dcda478-fa80-4e3e-bb35-0f622fe73a31",
    "metadata": {},
    "source": [
-    "## Define our Execution Agent\n",
+    "## 실행 에이전트 정의\n",
     "\n",
-    "Now we will create the execution agent we want to use to execute tasks. \n",
-    "Note that for this example, we will be using the same execution agent for each task, but this doesn't HAVE to be the case."
+    "이제 작업을 실행하는 데 사용할 실행 에이전트를 만들겠습니다.\n",
+    "이 예제에서는 모든 작업에 같은 실행 에이전트를 사용하지만, 반드시 이렇게 해야 하는 것은 아닙니다."
    ]
   },
   {
@@ -174,15 +171,15 @@
    "id": "5cf66804-44b2-4904-b1a7-17ad70b551f5",
    "metadata": {},
    "source": [
-    "## Define the State\n",
+    "## 상태 정의\n",
     "\n",
-    "Let's now start by defining the state the track for this agent.\n",
+    "이제 이 에이전트가 추적할 상태를 정의해 보겠습니다.\n",
     "\n",
-    "First, we will need to track the current plan. Let's represent that as a list of strings.\n",
+    "먼저 현재 계획을 추적해야 합니다. 문자열 리스트로 표현하겠습니다.\n",
     "\n",
-    "Next, we should track previously executed steps. Let's represent that as a list of tuples (these tuples will contain the step and then the result)\n",
+    "다음으로 이전에 실행한 단계를 추적해야 합니다. 단계와 결과를 담은 튜플의 리스트로 나타내겠습니다.\n",
     "\n",
-    "Finally, we need to have some state to represent the final response as well as the original input."
+    "마지막으로 최종 응답과 원래 입력을 표현할 상태도 필요합니다."
    ]
   },
   {
@@ -209,9 +206,9 @@
    "id": "1dbd770a-9941-40a9-977e-4d55359eee21",
    "metadata": {},
    "source": [
-    "## Planning Step\n",
+    "## 계획 단계\n",
     "\n",
-    "Let's now think about creating the planning step. This will use function calling to create a plan."
+    "이제 계획 단계를 만들어 보겠습니다. 이 단계에서는 함수 호출 기능을 활용해 계획을 생성합니다."
    ]
   },
   {
@@ -220,9 +217,9 @@
    "metadata": {},
    "source": [
     "<div class=\"admonition note\">\n",
-    "    <p class=\"admonition-title\">Using Pydantic with LangChain</p>\n",
+    "    <p class=\"admonition-title\">LangChain에서 Pydantic 사용하기</p>\n",
     "    <p>\n",
-    "        This notebook uses Pydantic v2 <code>BaseModel</code>, which requires <code>langchain-core >= 0.3</code>. Using <code>langchain-core < 0.3</code> will result in errors due to mixing of Pydantic v1 and v2 <code>BaseModels</code>.\n",
+    " 이 노트북은 Pydantic v2의 <code>BaseModel</code>을 사용하며, 이를 위해서는 <code>langchain-core >= 0.3</code>이 필요합니다. <code>langchain-core < 0.3</code>을 사용하면 Pydantic v1과 v2의 <code>BaseModel</code>을 섞어 쓰게 되어 오류가 발생합니다.\n",
     "    </p>\n",
     "</div>"
    ]
@@ -302,9 +299,9 @@
    "id": "6e09ad9d-6f90-4bdc-bb43-b1ce94517c29",
    "metadata": {},
    "source": [
-    "## Re-Plan Step\n",
+    "## 재계획 단계\n",
     "\n",
-    "Now, let's create a step that re-does the plan based on the result of the previous step."
+    "이제 이전 단계의 결과를 바탕으로 계획을 다시 세우는 단계를 만들어 보겠습니다."
    ]
   },
   {
@@ -360,9 +357,9 @@
    "id": "859abd13-6ba0-45ad-b341-e652dd5f755b",
    "metadata": {},
    "source": [
-    "## Create the Graph\n",
+    "## 그래프 생성\n",
     "\n",
-    "We can now create the graph!"
+    "이제 그래프를 만들 수 있습니다!"
    ]
   },
   {
@@ -506,9 +503,9 @@
    "id": "8bf585a9-0f1e-4910-bd00-65e7bb05b6e6",
    "metadata": {},
    "source": [
-    "## Conclusion\n",
+    "## 마무리\n",
     "\n",
-    "Congrats on making a plan-and-execute agent! One known limitations of the above design is that each task is still executed in sequence, meaning embarrassingly parallel operations all add to the total execution time. You could improve on this by having each task represented as a DAG (similar to LLMCompiler), rather than a regular list."
+    "계획-실행 에이전트를 완성한 것을 축하합니다! 위 설계의 알려진 제한 사항 중 하나는 각 작업이 여전히 순차적으로 실행된다는 점으로, 병렬로 처리할 수 있는 작업이라도 전체 실행 시간이 늘어난다는 의미입니다. 이를 개선하려면 각 작업을 일반 리스트 대신 DAG(LLMCompiler와 유사한 구조)로 표현할 수 있습니다."
    ]
   }
  ],

--- a/examples/plan-and-execute/plan-and-execute.ipynb
+++ b/examples/plan-and-execute/plan-and-execute.ipynb
@@ -5,7 +5,7 @@
    "id": "9138f92e",
    "metadata": {},
    "source": [
-    "This file has been moved to https://github.com/langchain-ai/langgraph/blob/main/docs/docs/tutorials/plan-and-execute/plan-and-execute.ipynb"
+    "이 파일은 https://github.com/langchain-ai/langgraph/blob/main/docs/docs/tutorials/plan-and-execute/plan-and-execute.ipynb 로 이동했습니다."
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- translate the plan-and-execute tutorial notebook text into Korean
- update the example pointer notebook message to Korean

## Testing
- not run (documentation change)

------
https://chatgpt.com/codex/tasks/task_e_68ccffcd07b48322820dc3eb9249e0f7